### PR TITLE
docs: yarn add instead of yarn install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Use [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/lang/en) to inst
 npm install --save svelte-json-tree
 
 # yarn
-yarn install svelte-json-tree
+yarn add svelte-json-tree
 ```
 
 ## Usage


### PR DESCRIPTION
From yarn docs:
If you are used to using npm you might be expecting to use _--save_ or _--save-dev_. These have been replaced by yarn add and yarn _add --dev_. For more information, see the [yarn add documentation](https://yarnpkg.com/en/docs/cli/add).
