### PR TITLE
Disable label warning

### DIFF
--- a/src/JSONKey.svelte
+++ b/src/JSONKey.svelte
@@ -14,6 +14,7 @@
   }
 </style>
 {#if showKey && key}
+  <!-- svelte-ignore a11y-label-has-associated-control -->
   <label class:spaced={isParentExpanded} on:click>
     <span>{key}{colon}</span>
   </label>

--- a/src/JSONNested.svelte
+++ b/src/JSONNested.svelte
@@ -53,6 +53,7 @@
   }
 </style>
 <li class:indent={isParentExpanded}>
+  <!-- svelte-ignore a11y-label-has-associated-control -->
   <label>
     {#if expandable && isParentExpanded}
       <JSONArrow on:click={toggleExpand} {expanded} />


### PR DESCRIPTION
disabled A form label must be associated with a control a11y warning logs.(`svelte-ignore`)

[official doc](https://svelte.dev/docs#Comments)

![ss1](https://user-images.githubusercontent.com/41711526/96349835-20e36880-10ed-11eb-8167-66c340ff55a3.png)

![ss2](https://user-images.githubusercontent.com/41711526/96349838-2640b300-10ed-11eb-8d56-c3452ffb1c60.png)


