### PR TITLE
Move `svelte` field to `exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "svelte2tsx": "^0.5.6",
     "typescript": "^4.6.3"
   },
-  "main": "./index.js",
   "exports": {
     ".": {
+      "svelte": "./index.js",
       "import": "./dist/es/index.js",
       "require": "./dist/cjs/index.js"
     },
@@ -55,6 +55,5 @@
     },
     "./standalone/umd": "./dist/standalone/umd/index.js"
   },
-  "svelte": "./index.js",
   "type": "module"
 }


### PR DESCRIPTION
This should fix the warning I'm getting:
>9:33:41 AM [vite-plugin-svelte] WARNING: The following packages use a svelte resolve configuration in package.json that has conflicting results and is going to cause problems future.
>
>svelte-json-tree@1.0.0
>
>Please see https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#conflicts-in-svelte-resolve for details.
